### PR TITLE
Added in Normal-Rayleigh model

### DIFF
--- a/R/sfm.R
+++ b/R/sfm.R
@@ -1,5 +1,5 @@
 sfm <- function(formula, 
-                model_name    = c("NHN","NHN-MDPD","NHN-PSI","NHN-MLQE","NHN_Z","NE","NE_Z","THT","NTN"), 
+                model_name    = c("NHN","NHN-MDPD","NHN-PSI","NHN-MLQE","NHN_Z","NE","NE_Z","NR","THT","NTN"), 
                 data, 
                 maxit.bobyqa  = 10000,
                 maxit.psoptim = 1000,
@@ -21,10 +21,10 @@ data_proc(formula,   data, model_name, individual = NULL, inefdec)
 start_cs( formula_x ,data_orig, x_vars_vec, intercept, model_name, n_x_vars, start_val,n_z_vars,z_vars) 
 data_proc2(data, data_x, fancy_vars, fancy_vars_z, data_z, y_var, x_vars_vec, halton_num=NA, individual=NA, N, model_name)
 
-if(model_name %in% c("NHN","NE","NHN-MDPD","NHN-PSI","NHN-MLQE","THT","NTN","NHN_Z","NE_Z") ){
+if(model_name %in% c("NHN","NE","NR","NHN-MDPD","NHN-PSI","NHN-MLQE","THT","NTN","NHN_Z","NE_Z") ){
 like.fn = function(x){
       
-      if(model_name %in% c("NHN","NE","NHN-MDPD","NHN-PSI","NHN-MLQE")){x_x_vec <- x[3:as.numeric(n_x_vars + 2)]}
+      if(model_name %in% c("NHN","NE","NR","NHN-MDPD","NHN-PSI","NHN-MLQE")){x_x_vec <- x[3:as.numeric(n_x_vars + 2)]}
       if(model_name ==     "THT"){                                      x_x_vec <- x[4:as.numeric(n_x_vars + 3)]}
       if(model_name ==     "NTN"){                                      x_x_vec <- x[4:as.numeric(n_x_vars + 3)]}
 
@@ -62,6 +62,14 @@ like.fn = function(x){
       l3    <- (eps/x[2]) + (x[1]^2 /  (2*x[2]^2)  )
       
       like  <-  l1+l2+l3}
+
+      if(model_name=="NR"){
+        sigv           <- x[1]
+        sigu          <- x[2]
+        sigma          <- sqrt(2*sigv**2+sigu^2)
+        z              <- (eps*sigu/sigv)/sigma
+        like           <- (log(sigv)- 2*log(sigma) - 1/2*(eps/sigv)^2 + 1/2*z^2 + 
+                          log(sqrt(2/pi)*exp(-1/2*z**2) - z*(1-erf(z/sqrt(2)))))}
       
       if(model_name == "NHN-MLQE"){
         NNN    <- length(data)

--- a/R/sfm.R
+++ b/R/sfm.R
@@ -58,6 +58,7 @@ like.fn = function(x){
       l1   <- log(1/x[2])
       l2   <- pnorm( -(eps/x[1]) - (x[1]    /x[2]), log.p = TRUE)
       l3   <- (eps/x[2]) + (x[1]^2 /  (2*x[2]^2)  )
+      like           <-  l1+l2+l3}
       
       if(model_name=="NR"){
         sigv           <- x[1]

--- a/R/starting.values.R
+++ b/R/starting.values.R
@@ -15,6 +15,7 @@ start_v_ntn    <- if(is.na(beta_0_st)) {unname(c(lambda,sigma,mu,beta_hat))}    
 start_v_t      <- if(is.na(beta_0_st)) {unname(c(sigma_u,sigma_v,1,beta_hat))}  else{unname(c(sigma_u,sigma_v,1,beta_0,beta_hat)) }
 start_v_ne     <- if(is.na(beta_0_st)) {unname(c(sigma_v,sigma_u,beta_hat))}    else{unname(c(sigma_v,sigma_u,beta_0,beta_hat)) }
 start_v_nhn    <- if(is.na(beta_0_st)) {unname(c(lambda,sigma,beta_hat))}       else{unname(c(lambda,sigma,beta_0,beta_hat)) }
+start_v_nr     <- if(is.na(beta_0_st)) {unname(c(sigma_v,sigma_u,beta_hat))}    else{unname(c(sigma_v,sigma_u,beta_0,beta_hat)) }
 start_v_zisf   <- if(is.na(beta_0_st)) {unname(c(gam,sigma_v,sigma_u,beta_hat))}else{unname(c(gam,sigma_v,sigma_u,beta_0,beta_hat)) }
 
 if(model_name %in% c("NHN_Z","NE_Z")){
@@ -44,6 +45,11 @@ if(model_name=="NE"){
   out            <- matrix(0,nrow = 3,ncol = length(start_v))
   colnames(out)  <- c("sigv","sigu",c(names(plm_lm$coefficients)))
   lower_bob      <- c(rep(.Machine$double.eps,2),rep(-Inf,n_x_vars))}
+if(model_name=="NR"){
+  start_v        <- start_v_nr
+  out            <- matrix(0,nrow = 3,ncol = length(start_v))
+  colnames(out)  <- c("sigv","sigu",c(names(plm_lm$coefficients)))
+  lower_bob      <- c(rep(.Machine$double.eps,2),rep(-Inf,n_x_vars))}
 if(model_name=="THT"){
   start_v        <- start_v_t
   out            <- matrix(0,nrow = 3,ncol = length(start_v))
@@ -60,7 +66,7 @@ if (isTRUE(is.numeric(start_val))) {start_v <- start_val}
 rownames(out)  <- c("par","st_err","t-val") 
 
 NAMES       <- c("plm_lm", "beta_hat", "epsilon_hat", "beta_0_st", "sigma_u", "sigma_v", "mu",
-                 "beta_0", "lambda", "sigma", "start_v_ntn", "start_v_t", "start_v_ne", "start_v_nhn",
+                 "beta_0", "lambda", "sigma", "start_v_ntn", "start_v_t", "start_v_ne", "start_v_nr", "start_v_nhn",
                  "start_v", "out", "lower_bob")
 
 for (X in NAMES){
@@ -179,7 +185,7 @@ rm(NAMES,X)}
 lower.start <- function(start_v, model_name, differ){
 if(model_name == "TRE"){                                                 lower1 <- c(rep(.0000001,3) ,  start_v[-c(1:3)] - differ)}
 if(model_name == "GTRE"){                                                lower1 <- c(rep(.0000001,4) ,  start_v[-c(1:4)] - differ)} 
-if(model_name %in% c("NHN","NE","NTN","NHN-MDPD","NHN-PSI","NHN-MLQE") ){lower1 <- c(rep(.0000001,2),   start_v[-c(1:2)] - differ )}
+if(model_name %in% c("NHN","NE","NR","NTN","NHN-MDPD","NHN-PSI","NHN-MLQE")){lower1 <- c(rep(.0000001,2),   start_v[-c(1:2)] - differ )}
 if(model_name =="THT"){                                                  lower1 <- c(rep(.0000001,3),   start_v[-c(1:3)] - differ )}  
 if(model_name %in% c("ZISF")){                                           lower1 <- c(start_v[1]-differ, rep(.0000001,2),   start_v[-c(1:3)] - differ)}  
 if(model_name %in% c("ZISF_Z")){                                         lower1 <- c(rep(.0000001,2),  start_v[-c(1:2)] - differ)}


### PR DESCRIPTION
Added option to estimate a Normal-Rayleigh model using the option "NR" in the sfm function. Seems to be working fine.

N.B. I have used a slightly different parameterisation to that usually used for the Rayleigh distribution (and used in Hajargasht's paper). The parameterisation I have used is that which arises if we start with a Nakagami distribution and set the shape parameter to 2. This is in order to make comparison easier -- I plan to add in the Nakagami model soon.

(this version should fix previous conflicts)